### PR TITLE
form: add the posssibility of setting the form's initial values

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,26 @@ function isNumber (value) {
 </FormState>
 ```
 
+### Setting Initial Values
+
+It's possible to set the initial values of the form by passing an object whose
+keys mirror form field structure, specifying the initial value for the fields.
+
+```jsx
+const FormState = require('./src/FormState.js');
+const Input = require('./src/CustomInput.js');
+
+<Form initialValues={{
+  name: 'Obi One Kenobi',
+  address: {
+    street: 'A galaxy far far away',
+    number: 123,
+  }
+}}>
+  <Input name="name" title="Full name" />
+  <fieldset name="address">
+    <Input name="street" title="Street" />
+    <Input type="number" name="number" title="House Number" />
+  </fieldset>
+ </Form>
+```

--- a/src/CustomInput.js
+++ b/src/CustomInput.js
@@ -1,9 +1,9 @@
 import React from 'react'
 
-const Input = ({ name, type, onChange, title }) => (
+const Input = ({ name, type, onChange, title, value }) => (
   <div>
     <label htmlFor={name}>{title}</label>
-    <input {...{ name, type, onChange }} />
+    <input {...{ name, type, onChange, value }} />
   </div>
 )
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default class Form extends Component {
 
     this.state = {
       errors: {},
-      values: {},
+      values: props.initialValues,
     }
 
     this.cloneTree = this.cloneTree.bind(this)
@@ -251,10 +251,16 @@ Form.propTypes = {
    * The form submit callback. Receives the serialized form as an object.
   **/
   onSubmit: func,
+  /**
+   * The initials values object whose keys mirror form field structure.
+   * This object sets the form's initial values
+   */
+  initialValues: object, // eslint-disable-line
 }
 
 Form.defaultProps = {
   children: null,
   validation: {},
+  initialValues: {},
   onSubmit: () => undefined,
 }


### PR DESCRIPTION
This pull request adds the possibility of of setting the initial values of the form. This will be necessary in pages that need to show data what was previously saved.