### PR TITLE
form: fix path comparison codition so it can work with arrays

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import {
   set,
   view,
   when,
+  not,
 } from 'ramda'
 
 
@@ -108,7 +109,7 @@ export default class Form extends Component {
       return element
     }
 
-    const name = element.props.name ? [element.props.name] : []
+    const name = not(isNil(element.props.name)) ? [element.props.name] : []
     const path = [...parentPath, ...name]
     const lens = lensPath(path)
 


### PR DESCRIPTION
Changed the props.name comparison condition so it can accept values such as 0 which was previously considered false. This will allow the react-vanilla-form to work with arrays of input or fieldsets.