### PR TITLE
chore: remove src folder from files key

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "license": "MIT",
   "private": false,
   "files": [
-    "src/index.js",
     "dist/index.js"
   ],
   "scripts": {


### PR DESCRIPTION
the files key should only contain the files that are going to be
installed when someone runs `npm i ...`, and as we use a dist folder for
that, there's no need to have the original src file