### PR TITLE
form: fix validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {
   lensPath,
   map,
   mergeAll,
+  not,
   partial,
   partialRight,
   pipe,
@@ -59,7 +60,7 @@ export default class Form extends Component {
     }
 
     if (validate.constructor === Array) {
-      const validationErrors = reject(isNil, ap(validate, [view(lens, values)]))
+      const validationErrors = reject(not, ap(validate, [view(lens, values)]))
 
       if (validationErrors.length > 0) {
         const validation = validationErrors[0]


### PR DESCRIPTION
The validationErrors returns an array with the result of all validations. The problem is with this aspect. Changing to `not`, reject function will return only the error messages, removing the 'false' states, when the validate is ok.