### PR TITLE
Fix validate recursion when the form is submitted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,8 +225,9 @@ export default class Form extends Component {
       return errors
     }
 
-    if (is(Array, element.props.children)) {
-      const { children } = element.props
+    const children = React.Children.toArray(element.props.children)
+
+    if (children.length) {
       const path = element.props.name
         ? [...parentPath, element.props.name]
         : parentPath

--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ export default class Form extends Component {
     return element
   }
 
-  validateTree (errors, element, parentPath = []) {
+  validateTree (errors = {}, element, parentPath = []) {
     if (typeof element === 'string') {
       return errors
     }
@@ -234,7 +234,7 @@ export default class Form extends Component {
 
       const validated = reduce(
         partialRight(this.validateTree, [path]),
-        {},
+        errors,
         children
       )
 


### PR DESCRIPTION
This change allows the input to be inside other divs or any other
html element.

This validation works now when the form is submitted:
```jsx
<div className="row">
  <div className="col">
    <input name="email" />
  </div>
</div>
```

Another change adjusts so that when it has 2 inputs or more the error is propagated, it happened that the error object was empty during the iteration.

Closes: #17 