### PR TITLE
validation: remove willmount behaviour

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,20 +56,17 @@ export default class Form extends Component {
     this.handleSubmit = this.handleSubmit.bind(this)
   }
 
-  componentWillMount () {
-    if (!this.props.errors && this.props.data) {
-      this.setState({
-        errors: this.validateTree({}, this),
-      })
-    }
-  }
-
   componentWillReceiveProps (nextProps) {
     const { data, errors } = nextProps
 
     if (data && !equals(data, this.props.data)) {
-      const errors = this.validateTree(this.state.errors, this)
-      this.setState({ data, errors })
+      this.setState(
+        { data },
+        () => {
+          const errors = this.validateTree({}, this)
+          this.setState({ errors })
+        }
+      )
     }
 
     if (errors && !equals(errors, this.props.errors)) {
@@ -308,10 +305,11 @@ export default class Form extends Component {
       this.state.errors,
       this
     )
-
-    this.setState({ errors })
-
-    this.props.onSubmit(this.state.data, this.state.errors)
+ 
+    this.setState(
+      { errors },
+      () => this.props.onSubmit(this.state.data, this.state.errors)
+    )
   }
 
   render () {


### PR DESCRIPTION
the component `willUnmount` validation was causing the form to be
validated before the user changes anything, which can cause some
confusion

also, add the form `onChange` function to be called as a callback of
`setState`, so it doesn't mess with async stuff


on `willReceiveProps` the error validation should wait for the data state to change, so I moved it to the callback of `setState` and the error should not consider what's previously on the `state.error`

closes https://github.com/pagarme/mercurio/issues/79 
closes https://github.com/pagarme/mercurio/issues/82 