### PR TITLE
form: fix props update when passing data & error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,28 +64,40 @@ export default class Form extends Component {
     this.notifyChangeEvent = this.notifyChangeEvent.bind(this)
     this.handleEvent = this.handleEvent.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
+    this.mergeErrors = this.mergeErrors.bind(this)
 
     if (props.validateDataProp) {
       this.state.errors = this.validateTree(this.state.errors, this)
     }
   }
 
+  mergeErrors (newErrors) {
+    if (newErrors && !equals(newErrors, this.state.errors)) {
+      this.setState({ errors: merge(this.state.errors, newErrors) })
+    }
+  }
+
   componentWillReceiveProps (nextProps) {
-    const { data, errors } = nextProps
+    const { data, errors: nextErrors } = nextProps
 
     if (data && !equals(data, this.props.data)) {
       this.setState({ data }, () => {
         if (this.props.validateDataProp) {
           const errors = this.validateTree(this.state.errors, this)
+
+          if (nextErrors && !equals(errors, nextErrors)) {
+            this.setState({ errors: merge(errors, nextErrors) })
+            return
+          }
           this.setState({ errors })
+          return
         }
+        this.mergeErrors(nextErrors)
       })
       return
     }
 
-    if (errors && !equals(errors, this.props.errors)) {
-      this.setState({ errors: merge(this.state.errors, errors) })
-    }
+    this.mergeErrors(nextErrors)
   }
 
   notifyChangeEvent () {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,6 +5,7 @@ import Adapter from 'enzyme-adapter-react-16'
 import {
   assocPath,
   dissocPath,
+  merge,
 } from 'ramda'
 
 import Form from '.'
@@ -647,5 +648,33 @@ describe('Errors prop', () => {
     wrapper.update()
 
     assertPropsEquals('error', wrapper, errors)
+  })
+
+  test('merge errors via prop with state errors when passing data and error', () => {
+    const wrapper = mount(
+      <Form
+        validation={baseValidation}
+        validateDataProp
+      >
+        {renderBaseInputs()}
+      </Form>
+    )
+
+    assertPropsEquals('error', wrapper, baseErrors)
+
+    const errors = {
+      name: 'must be another name'
+    }
+
+    wrapper.setProps({
+      data: {
+        name: '',
+      },
+      errors,
+    })
+
+    wrapper.update()
+
+    assertPropsEquals('error', wrapper, merge(baseErrors, errors))
   })
 })


### PR DESCRIPTION
currently if both properties are passed to the `Form` at the same time the `componentWillReceiveProps` returns before executing the block that handles `errors`. this PR removes the `return` inside the `data` handle block