### PR TITLE
form: remove error message on focus

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -518,6 +518,35 @@ describe('Form Validation', () => {
 
     expect(error).toEqual(baseErrors.number)
   })
+
+  test('removes input error message on focus', () => {
+    const onChange = jest.fn()
+
+    const wrapper = mount(
+      <Form
+        onChange={onChange}
+        data={{
+          name: 'my name',
+          age: '20',
+        }}
+        errors={{
+          name: 'my name error',
+          age: 'my age error',
+        }}
+      >
+        <input name="name" />
+        <input name="age" />
+      </Form>
+    )
+
+    focus(wrapper, { name: 'name' })
+    change(wrapper, { name: 'name' }, 'other name')
+
+    const data = {name: 'other name', age: '20'}
+    const errors = {age: 'my age error'}
+
+    expect(onChange).toHaveBeenCalledWith(data, errors)
+  })
 })
 
 describe('Data prop', () => {


### PR DESCRIPTION
Currently, if an input is marked with an error and the user goes back to it and types it correctly, the error message will only go away during the next validation event. From a UX standpoint this is bad for the user, since he will still be told the input is incorrect, even if he just typed it correctly. This is only not the case on the `change` event, but running validations on every change can be expensive.

This PR introduces a new behavior: when an input with an error message is focused, the error message goes away. This solves both the UX problem, by clearing the error message before the user starts typing again, and the performance error, by running it only during the `focus` event. The error can still return on the next validation event if the input remains wrong.

This new behavior does not happen when the validation is set to occur on the `focus` event, so error clearing does not override focus validation.

This new behavior can be disabled by setting a new boolean prop `keepErrorOnFocus`, if necessary.