### PR TITLE
Add a props bypass from Form class to form component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import {
   isNil,
   lensPath,
   merge,
+  omit,
   partial,
   partialRight,
   pathSatisfies,
@@ -46,6 +47,20 @@ const isCheckable = element =>
   element.props.type === 'checkbox' ||
   typeof element.props.checked !== 'undefined' ||
   typeof (element.type.defaultProps || {}).checked !== 'undefined'
+
+const ownProps = [
+  'children',
+  'customErrorProp',
+  'data',
+  'onChange',
+  'onSubmit',
+  'keepErrorOnFocus',
+  'validateDataProp',
+  'validateOn',
+  'validation',
+]
+
+const omitOwnProps = omit(ownProps)
 
 // eslint-disable-next-line react/no-deprecated
 export default class Form extends Component {
@@ -327,10 +342,11 @@ export default class Form extends Component {
   }
 
   render () {
-    const { className } = this.props
-
     return (
-      <form onSubmit={this.handleSubmit} className={className}>
+      <form
+        onSubmit={this.handleSubmit}
+        {...omitOwnProps(this.props)}
+      >
         {React.Children.map(
           this.props.children,
           partialRight(this.cloneTree, [this, []])
@@ -394,12 +410,10 @@ Form.propTypes = {
    * Not applicable if `validateOn` is set to `focus`.
    */
   keepErrorOnFocus: bool,
-  className: string,
 }
 
 Form.defaultProps = {
   children: undefined,
-  className: '',
   customErrorProp: undefined,
   data: undefined,
   onChange: undefined,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -707,3 +707,17 @@ describe('Errors prop', () => {
     assertPropsEquals('error', wrapper, merge(baseErrors, errors))
   })
 })
+
+describe('Own props', () => {
+  test('pass native form props to inner form component', () => {
+    const wrapper = mount(
+      <Form
+        className="Xuxa"
+        noValidate
+      />
+    )
+
+    expect(getProp('className', wrapper, 'form')).toEqual('Xuxa')
+    expect(getProp('noValidate', wrapper, 'form')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Add a props bypass to pass down all non-custom props to form component.
Resolves https://github.com/derekstavis/react-vanilla-form/issues/30