### PR TITLE
form: pass current form data to validators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,7 @@ export default class Form extends Component {
 
     if (is(Array, validation)) {
       for (let validate of validation) {
-        const err = validate(value)
+        const err = validate(value, data)
 
         if (!isErrorEmpty(err)) {
           return set(lens, err, errors)
@@ -144,7 +144,7 @@ export default class Form extends Component {
     }
 
     else if (typeof validation === 'function') {
-      const err = validation(value)
+      const err = validation(value, data)
 
       if (!isErrorEmpty(err)) {
         return set(lens, err, errors)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -381,6 +381,35 @@ describe('Form Validation', () => {
     )
   })
 
+  test('receives current form data', () => {
+    const passwordConfirmationValidator = jest.fn()
+    const value = '1234'
+
+    const currentData = {
+      password: '123456789',
+      passwordConfirmation: '1234'
+    }
+
+    const wrapper = mount(
+      <Form
+        data={{
+          password: '123456789',
+          passwordConfirmation: '1234'
+        }}
+        validation={{
+          passwordConfirmation: passwordConfirmationValidator,
+        }}
+      >
+        <input name="password"/>
+        <input name="passwordConfirmation"/>
+      </Form>
+    )
+
+    change(wrapper, { name: 'passwordConfirmation' }, value)
+
+    expect(passwordConfirmationValidator).toHaveBeenNthCalledWith(1, value, currentData)
+  })
+
   test('does not validate the input when default is prevented', () => {
     const onChange = jest.fn()
 


### PR DESCRIPTION
I have enhance the validator to receive the current data of the form. This is needed for validators that depends on other input data such as when you need to check whether the password input is equal to the passwordConfirmation or not

```
<Form validation={validation}>
          <CustomInput
            name="password"
            label="Senha"
            white
            required
          />
          <CustomInput
            name="passwordConfirmation"
            label="Confirme senha"
            required
            white
          />
          <Button
            block
          >
            Redefinir
          </Button>
 </Form>
```